### PR TITLE
Make emojiunicode.raw function always return a string

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -18,5 +18,5 @@ Get the unicode code of an emoji in base 16.
 - **String** `input`: The emoji character.
 
 #### Return
-- **Number** The unicode code.
+- **String** The unicode code points.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,12 +15,12 @@ function emojiUnicode (input) {
 
 /**
  * emojiunicode.raw
- * Get the unicode code(s) of an emoji in base 16.
+ * Get the unicode code points of an emoji in base 16.
  *
  * @name emojiunicode.raw
  * @function
  * @param {String} input The emoji character.
- * @returns {String} A string containing one or more unicode codes.
+ * @returns {String} The unicode code points.
  */
 emojiUnicode.raw = function (input) {
     if (input.length === 1) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,7 @@
  * @returns {String} The base 16 unicode code.
  */
 function emojiUnicode (input) {
-    return emojiUnicode.raw(input).map(val => parseInt(val).toString(16)).join(' ')
+    return emojiUnicode.raw(input).split(' ').map(val => parseInt(val).toString(16)).join(' ')
 }
 
 /**
@@ -20,11 +20,11 @@ function emojiUnicode (input) {
  * @name emojiunicode.raw
  * @function
  * @param {String} input The emoji character.
- * @returns {Array.Number} An array containing one or more unicode codes.
+ * @returns {String} A string containing one or more unicode codes.
  */
 emojiUnicode.raw = function (input) {
     if (input.length === 1) {
-        return [input.charCodeAt(0)];
+        return input.charCodeAt(0).toString();
     }
     else if (input.length > 1) {
         const pairs = [];
@@ -47,10 +47,10 @@ emojiUnicode.raw = function (input) {
                 pairs.push(input.charCodeAt(i))
             }
         }
-        return pairs;
+        return pairs.join(' ');
     }
 
-    return [];
+    return '';
 };
 
 module.exports = emojiUnicode;

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,7 @@ function emojiUnicode (input) {
  * @name emojiunicode.raw
  * @function
  * @param {String} input The emoji character.
- * @returns {Array.number} An array containing one or more unicode codes.
+ * @returns {Array.Number} An array containing one or more unicode codes.
  */
 emojiUnicode.raw = function (input) {
     if (input.length === 1) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,23 +10,23 @@
  * @returns {String} The base 16 unicode code.
  */
 function emojiUnicode (input) {
-    return emojiUnicode.raw(input).split(' ').map(val => parseInt(val).toString(16)).join(' ')
+    return emojiUnicode.raw(input).map(val => parseInt(val).toString(16)).join(' ')
 }
 
 /**
  * emojiunicode.raw
- * Get the unicode code of an emoji in base 16.
+ * Get the unicode code(s) of an emoji in base 16.
  *
  * @name emojiunicode.raw
  * @function
  * @param {String} input The emoji character.
- * @returns {Number} The unicode code.
+ * @returns {Array.number} An array containing one or more unicode codes.
  */
 emojiUnicode.raw = function (input) {
     if (input.length === 1) {
-        return input.charCodeAt(0);
+        return [input.charCodeAt(0)];
     }
-    if (input.length > 1) {
+    else if (input.length > 1) {
         const pairs = [];
         for (var i = 0; i < input.length; i++) {
             if (
@@ -37,23 +37,20 @@ emojiUnicode.raw = function (input) {
                     input.charCodeAt(i + 1) >= 0xdc00 && input.charCodeAt(i + 1) <= 0xdfff
                 ) {
                     // low surrogate
-                    let comp = (
+                    pairs.push(
                         (input.charCodeAt(i) - 0xd800) * 0x400
                       + (input.charCodeAt(i + 1) - 0xdc00) + 0x10000
                     );
-                    pairs.push(comp)
                 }
             } else if (input.charCodeAt(i) < 0xd800 || input.charCodeAt(i) > 0xdfff) {
                 // modifiers and joiners
                 pairs.push(input.charCodeAt(i))
             }
         }
-        return pairs.join(' ')
+        return pairs;
     }
-    if (comp < 0) {
-        return input.charCodeAt(0);
-    }
-    return comp;
+
+    return [];
 };
 
 module.exports = emojiUnicode;

--- a/test/index.js
+++ b/test/index.js
@@ -11,6 +11,8 @@ tester.describe("✨", t => {
         t.expect(toUnicode("🍨")).toEqual("1f368");
         t.expect(toUnicode("💅🏿")).toEqual("1f485 1f3ff");
     	t.expect(toUnicode("👯‍♂️")).toEqual("1f46f 200d 2642 fe0f");
-    	t.expect(toUnicode("🇪🇨")).toEqual("1f1ea 1f1e8");
+        t.expect(toUnicode("🇪🇨")).toEqual("1f1ea 1f1e8");
+        t.expect(toUnicode("⭕")).toEqual("2b55");
+        t.expect(toUnicode("🇳🇱")).toEqual("1f1f3 1f1f1");
     });
 });


### PR DESCRIPTION
Bug found when getting unicode of emoji ⭕

The emojiunicode.raw function could return a number from the `string.chartAt()` function or a string from `pairs.join(' ')`, this caused a `TypeError: emojiUnicode.raw(...).split is not a function` at `emojiUnicode()` line 13. 

`emojiUnicode.raw` now always returns a string of unicode code points and an empty string if input length of 0.